### PR TITLE
Components importer

### DIFF
--- a/grunt/nunjuckr.js
+++ b/grunt/nunjuckr.js
@@ -4,6 +4,8 @@
  */
 
 module.exports = function( grunt, options ) {
+    var ComponentsLoader = require( './nunjucks/components-loader.js' );
+
     return {
         options: {
             globals: {
@@ -15,6 +17,7 @@ module.exports = function( grunt, options ) {
                 srcPath: '<%= srcPath %>',
                 production: true
             },
+            loader: new ComponentsLoader( options.srcPath ),
             ext: '.html'
         },
         production: {

--- a/grunt/nunjucks/components-loader.js
+++ b/grunt/nunjucks/components-loader.js
@@ -1,0 +1,49 @@
+/**
+ * Components Loader for nunjucks
+ */
+var fs = require( 'fs' );
+var glob = require( 'glob' );
+var camelcase = require( 'camelcase' );
+
+var ComponentsLoader = require( 'nunjucks' ).Loader.extend( {
+    init: function( srcPath ) {
+        this.srcPath = srcPath;
+    },
+
+    getSource: function( name ) {
+        var componentsPath = this.srcPath + 'components/' + name;
+
+        try {
+            var stats = fs.statSync( componentsPath );
+            if ( stats.isDirectory() ) {
+                var files = glob.sync( '**/*.njs', {
+                    cwd: componentsPath
+                } );
+
+                var loadingSrc = '';
+                var file = files.pop();
+
+                while ( file !== undefined  ) {
+                    var componentName = camelcase( file.match( /^[\w\-]+/ )[ 0 ] );
+
+                    loadingSrc += '{% import "' + componentsPath + '/' + file + '" as ' + componentName + ' %}\n';
+                    loadingSrc += '{% set ' + componentName + ' = ' + componentName + ' %}\n';
+
+                    file = files.pop();
+                }
+
+                return {
+                    src: loadingSrc,
+                    path: name,
+                    noCache: false
+                };
+            } else {
+                return false;
+            }
+        } catch ( e ) {
+            return false;
+        }
+    }
+} );
+
+module.exports = ComponentsLoader;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "test": "grunt lint_ci && scss-lint --require=scss_lint_reporter_checkstyle --format=Checkstyle src/ -o artifacts/test/scss-lint-report.checkstyle.xml && grunt karma:ci && grunt production"
   },
   "dependencies": {
+    "camelcase": "^2.1.1",
+    "glob": "^7.0.3",
     "grunt": "0.4.5",
     "grunt-autoprefixer": "3.0.3",
     "grunt-contrib-clean": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "grunt-contrib-requirejs": "0.4.4",
     "grunt-contrib-watch": "0.6.1",
     "grunt-jscs": "2.3.0",
-    "grunt-nunjuckr": "1.4.0",
+    "grunt-nunjuckr": "^1.5.0",
     "grunt-sass": "1.1.0",
     "grunt-sass-globbing": "1.4.0",
     "grunt-scss-lint": "0.3.8",

--- a/src/components/site/pages/example.njs
+++ b/src/components/site/pages/example.njs
@@ -1,4 +1,5 @@
-{% import modulesPath + "example-module/example-module.njs" as example %}
+{% import 'modules' as modules %}
+{% import 'patterns' as patterns %}
 
 {% extends templatePath + "default.njs" %}
 
@@ -11,15 +12,15 @@
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dolorum repudiandae esse dolores quos minus perspiciatis laboriosam magni ipsum, optio sed quae aliquid sequi consectetur eaque vel, est ducimus similique illum. Debitis ea dolorum temporibus doloremque ratione, nesciunt aspernatur. Velit saepe dicta ipsa minus iusto odit ex, obcaecati temporibus, sint deserunt.
     </p>
 
-    {{ example.macro() }}
-    {{ example.macro(true) }}
-    {{ example.macro(true) }}
-    {{ example.macro(true) }}
-    {{ example.macro(true) }}
-    {{ example.macro(true) }}
-    {{ example.macro(true) }}
-    {{ example.macro(true) }}
-    {{ example.macro(true) }}
-    {{ example.macro(true) }}
-    {{ example.macro(true) }}
+    {{ modules.exampleModule.macro() }}
+    {{ modules.exampleModule.macro(true) }}
+    {{ modules.exampleModule.macro(true) }}
+    {{ modules.exampleModule.macro(true) }}
+    {{ modules.exampleModule.macro(true) }}
+    {{ modules.exampleModule.macro(true) }}
+    {{ modules.exampleModule.macro(true) }}
+    {{ modules.exampleModule.macro(true) }}
+    {{ modules.exampleModule.macro(true) }}
+    {{ modules.exampleModule.macro(true) }}
+    {{ modules.exampleModule.macro(true) }}
 {% endblock %}


### PR DESCRIPTION
Adds a nunjucks importer for the components. All components of one category (e.g. pattern and modules) can be imported with one import statement in nunjucks.

The macros and variables of all components in the selected category get merged into a collection. They can be accessed by their folder name as the namespace.

Here is a small example:

``` twig
{% import "modules" as modules %}

{{ modules.example.macro() }}
```
