### PR TITLE
Makes it possible to load all files in modules/patterns directory

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -43,7 +43,7 @@ sind. Dazu wurde ein spezieller Importer entwickelt, der es ermöglicht alle Mod
 importieren und somit weniger `import`-Statements in einer Datei angeben zu müssen.
 
 Module können einfach mit `{% import 'modules' as modules %}` in die Variable `modules` importiert werden. Danach kann einfach über
-`{{ modules.ordnername.macroname() }}` auf das Modul zugegriffen werden. Für Pattern existiert ein analoger Mechanismus
+`{{ modules.ordnername.dateiname.macroname() }}` auf das Modul zugegriffen werden. Für Pattern existiert ein analoger Mechanismus
 (`{% import 'patterns' as patterns %}`).
 
 > __Achtung:__ Werden alle Module in einem Modul importiert entsteht eine unendliche Rekursion und das Templating funktioniert

--- a/docs/templating_en.md
+++ b/docs/templating_en.md
@@ -43,7 +43,7 @@ purpose we developed a special importer for nunjucks. This importer makes it pos
 with just one `import` statement.
 
 Modules can be imported with `{% import 'modules' as modules %}` into the variable `modules`. Afterwards they can be used
-with `{{ modules.ordnername.macroname() }}`. Pattern can be imported and used in a similar way (`{% import 'patterns' as patterns %}`).
+with `{{ modules.ordnername.filename.macroname() }}`. Pattern can be imported and used in a similar way (`{% import 'patterns' as patterns %}`).
 
 > __Warning:__ Be careful when importing a module into another module. Importing all modules into a module leads to an infinite loop.
 This breaks the template rendering. The same applies for pattern.

--- a/grunt/nunjuckr.js
+++ b/grunt/nunjuckr.js
@@ -15,7 +15,10 @@ module.exports = function( grunt, options ) {
                 patternsPath: '<%= srcPath %>components/patterns/',
                 appPath: '<%= srcPath %>components/app/',
                 srcPath: '<%= srcPath %>',
-                production: true
+                production: true,
+                append: function( targetObj, key, data ) {
+                    targetObj[ key ] = data;
+                }
             },
             loader: new ComponentsLoader( options.srcPath ),
             ext: '.html'
@@ -41,7 +44,10 @@ module.exports = function( grunt, options ) {
                     appPath: '<%= srcPath %>components/app/',
                     srcPath: '<%= srcPath %>',
                     production: false,
-                    liveReloadPort: '<%= liveReloadPort %>'
+                    liveReloadPort: '<%= liveReloadPort %>',
+                    append: function( targetObj, key, data ) {
+                        targetObj[ key ] = data;
+                    }
                 }
             },
             files: [

--- a/grunt/nunjucks/components-loader.js
+++ b/grunt/nunjucks/components-loader.js
@@ -22,12 +22,22 @@ var ComponentsLoader = require( 'nunjucks' ).Loader.extend( {
 
                 var loadingSrc = '';
                 var file = files.pop();
+                var loadedBaseNames = [];
 
                 while ( file !== undefined  ) {
-                    var componentName = camelcase( file.match( /^[\w\-]+/ )[ 0 ] );
+                    var componentBaseName = camelcase( file.match( /^[\w\-]+/ )[ 0 ] );
+                    var componentName = camelcase( file.match( /([\w\-]+)\.njs$/ )[ 1 ] );
 
-                    loadingSrc += '{% import "' + componentsPath + '/' + file + '" as ' + componentName + ' %}\n';
-                    loadingSrc += '{% set ' + componentName + ' = ' + componentName + ' %}\n';
+                    if ( !~loadedBaseNames.indexOf( componentBaseName ) ) {
+                        loadedBaseNames.push( componentBaseName );
+                        loadingSrc += '{% set ' + componentBaseName + ' = {} %}\n';
+                    }
+
+                    loadingSrc += '{% import "' + componentsPath + '/' + file + '" as ' +
+                        componentBaseName + componentName + ' %}\n';
+                    loadingSrc += '{{ append(' + componentBaseName + ', "' +
+                        componentName + '", ' +
+                        componentBaseName + componentName + ') }}\n';
 
                     file = files.pop();
                 }

--- a/src/components/site/pages/example.njs
+++ b/src/components/site/pages/example.njs
@@ -12,15 +12,15 @@
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dolorum repudiandae esse dolores quos minus perspiciatis laboriosam magni ipsum, optio sed quae aliquid sequi consectetur eaque vel, est ducimus similique illum. Debitis ea dolorum temporibus doloremque ratione, nesciunt aspernatur. Velit saepe dicta ipsa minus iusto odit ex, obcaecati temporibus, sint deserunt.
     </p>
 
-    {{ modules.exampleModule.macro() }}
-    {{ modules.exampleModule.macro(true) }}
-    {{ modules.exampleModule.macro(true) }}
-    {{ modules.exampleModule.macro(true) }}
-    {{ modules.exampleModule.macro(true) }}
-    {{ modules.exampleModule.macro(true) }}
-    {{ modules.exampleModule.macro(true) }}
-    {{ modules.exampleModule.macro(true) }}
-    {{ modules.exampleModule.macro(true) }}
-    {{ modules.exampleModule.macro(true) }}
-    {{ modules.exampleModule.macro(true) }}
+    {{ modules.exampleModule.exampleModule.macro() }}
+    {{ modules.exampleModule.exampleModule.macro(true) }}
+    {{ modules.exampleModule.exampleModule.macro(true) }}
+    {{ modules.exampleModule.exampleModule.macro(true) }}
+    {{ modules.exampleModule.exampleModule.macro(true) }}
+    {{ modules.exampleModule.exampleModule.macro(true) }}
+    {{ modules.exampleModule.exampleModule.macro(true) }}
+    {{ modules.exampleModule.exampleModule.macro(true) }}
+    {{ modules.exampleModule.exampleModule.macro(true) }}
+    {{ modules.exampleModule.exampleModule.macro(true) }}
+    {{ modules.exampleModule.exampleModule.macro(true) }}
 {% endblock %}


### PR DESCRIPTION
This is a kind of bugfix for the components loader. The bug was in the idea of the components loader but now was fixed. Unfortunatly this was not possible in a way where no BCs were introduced, so this PR should go directly into version 3 of the denkstrap-structure.

I only put this here so it won't get lost on the way.