### PR TITLE
Adds error handling for Require.js

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -126,7 +126,7 @@ define([
 
   load.init( global, arg1, arg2 );
   load.init( local,  arg1, arg2 );
-  
+
   // Variablenzuweisung ist ebenfalls möglich
   var globalModule = load.init( global, arg1, arg2 );
   var localModule  = load.init( local,  arg1, arg2 );
@@ -434,44 +434,44 @@ Für literale Objekte z.B. Funktionssammlungen ist es nicht notwendig als Grundl
 Eine Konfiguration für verschiedene Umgebungen ist durch den require.js Build möglich. Die entsprechenden Dateien liegen im `app/config` Ordner. Hier können Optionen pro Modul bzw. globale Optionen hinterlegt werden. Über die Methoden `get` und `set` können sie entsprechend abgerufen und gesetzt werden.
 
 Die Konfiguration ist über `config` im define-Block zu laden. Beispiel:
- 
+
  ```javascript
  define( [ 'config' ], function( config ) {
-   // Holt die Konfiguration für das Modul foo
-   var fooConfig = config.get( 'foo' );  
+   // Holt die Konfiguration für das Modul example
+   var fooConfig = config.get( 'example' );
  } );
  ```
- 
+
  ### Require.js Error Handler
- 
+
  Im globalen Block der Config-Datei kann eine Funktion mit dem Namen `requireError` hinterlegt werden. Damit können spezielle Fehlerbehandlungen für Fehler beim Laden implementiert werden. Dies kann genutzt werden, wenn bestimmte Scripte aus einem CDN geladen werden. Passiert hier ein Fehler und ein Script wird nicht geladen, dann kann der Fehler direkt im Analytics- oder Log-Tool gespeichert werden und ein eventueller Fehler wird schneller entdeckt.
-  
+
   ```javascript
   ( function( window, define, require, undefined ) {
       'use strict';
-      
+
       /*
        * ...
        */
-  
+
           var config = {
               /*
                * ...
                */
-              
+
               requireError: function( err ) {
                   // Error-Handling
               }
-              
+
               /*
                * ...
                */
           };
-  
+
     /*
      * ...
      */
-  
+
   }( this, this.define, this.require ) );
   ```
 
@@ -543,7 +543,7 @@ Um Module nur unter bestimmten Bedingungen zu laden, können Conditions angelegt
 
             'in-viewport': function( load, element ) { ... },
             'is-visible' : function( load, element ) { ... }
-            
+
         };
     } );
 
@@ -552,7 +552,7 @@ Um Module nur unter bestimmten Bedingungen zu laden, können Conditions angelegt
 
 ###Funktionsweise
 
-Wenn ein Modul mit einer Condition verknüpft wird (siehe [Einbindung im HTML](#einbindung-im-html)), bestimmt diese den Zeitpunkt der Initialisierung. Dafür bekommt die Condition die beiden Argumente `load` und `element` übergeben. Die Funktion `load` initialisiert das Modul. `element` beinhaltet das HTMLElement, auf dem das Modul initialisiert werden soll. 
+Wenn ein Modul mit einer Condition verknüpft wird (siehe [Einbindung im HTML](#einbindung-im-html)), bestimmt diese den Zeitpunkt der Initialisierung. Dafür bekommt die Condition die beiden Argumente `load` und `element` übergeben. Die Funktion `load` initialisiert das Modul. `element` beinhaltet das HTMLElement, auf dem das Modul initialisiert werden soll.
 
 > **Wichtig:** Wird in der Condition die load-Funktion nicht ausgeführt, wird das Modul nicht initialisiert.
 
@@ -566,7 +566,7 @@ Wenn ein Modul mit einer Condition verknüpft wird (siehe [Einbindung im HTML](#
 
     // Listener wird initial und beim Scroll-Event ausgeführt
     function listener () {
-    
+
         if ( check() ) {
             // Bei positiver Überprüfung wird der Scroll-Eventlistener gelöscht
             // und das Modul initialisiert

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -14,6 +14,7 @@
       - [Beispiele](#beispiele)
 - [Extensions](#extensions)
 - [Funktionssammlungen](#funktionssammlungen)
+- [Konfiguration](#konfiguration)
 - [Events](#events-1)
 - [Conditions](#conditions)
 - [Loader](#loader)
@@ -427,6 +428,52 @@ Für literale Objekte z.B. Funktionssammlungen ist es nicht notwendig als Grundl
 
 }( this, this.define, this.require ));
 ```
+
+## Konfiguration
+
+Eine Konfiguration für verschiedene Umgebungen ist durch den require.js Build möglich. Die entsprechenden Dateien liegen im `app/config` Ordner. Hier können Optionen pro Modul bzw. globale Optionen hinterlegt werden. Über die Methoden `get` und `set` können sie entsprechend abgerufen und gesetzt werden.
+
+Die Konfiguration ist über `config` im define-Block zu laden. Beispiel:
+ 
+ ```javascript
+ define( [ 'config' ], function( config ) {
+   // Holt die Konfiguration für das Modul foo
+   var fooConfig = config.get( 'foo' );  
+ } );
+ ```
+ 
+ ### Require.js Error Handler
+ 
+ Im globalen Block der Config-Datei kann eine Funktion mit dem Namen `requireError` hinterlegt werden. Damit können spezielle Fehlerbehandlungen für Fehler beim Laden implementiert werden. Dies kann genutzt werden, wenn bestimmte Scripte aus einem CDN geladen werden. Passiert hier ein Fehler und ein Script wird nicht geladen, dann kann der Fehler direkt im Analytics- oder Log-Tool gespeichert werden und ein eventueller Fehler wird schneller entdeckt.
+  
+  ```javascript
+  ( function( window, define, require, undefined ) {
+      'use strict';
+      
+      /*
+       * ...
+       */
+  
+          var config = {
+              /*
+               * ...
+               */
+              
+              requireError: function( err ) {
+                  // Error-Handling
+              }
+              
+              /*
+               * ...
+               */
+          };
+  
+    /*
+     * ...
+     */
+  
+  }( this, this.define, this.require ) );
+  ```
 
 ## Events
 

--- a/docs/javascript_en.md
+++ b/docs/javascript_en.md
@@ -14,6 +14,7 @@
       - [Examples](#examples)
 - [Extensions](#extensions)
 - [Collections](#collections)
+- [Configuration](#configuration)
 - [Events](#events-1)
 - [Conditions](#conditions-1)
 - [Loader](#loader)
@@ -425,6 +426,52 @@ Its not necessary to create a module for a collection of functions. For this cas
 
 }( this, this.define, this.require ));
 ```
+
+## Configuration
+
+It is possible to provide different configurations for different environments. This is archieved using the require.js build. All configuration files are in the `app/config` folder. Here you can provide configs for a specific module or global configs. You can get and set those via the `get` and `set` methods. 
+
+The configurations are loaded via `config` in the define-block. E.g.:
+ 
+ ```javascript
+ define( [ 'config' ], function( config ) {
+   // get configs for module foo
+   var fooConfig = config.get( 'foo' );  
+ } );
+ ```
+ 
+ ### Require.js error handler
+ 
+ There is a function called `requireError` in the global block of the configs. With this function you can implement a special error handling for errors during script loading from require.js. You can use this to track if scripts loaded from a CDN can be loaded. If not you can implement an error handler pushing an event to your analytics or your logging tool. Then you can see the error really early.
+ 
+  ```javascript
+  ( function( window, define, require, undefined ) {
+      'use strict';
+      
+      /*
+       * ...
+       */
+  
+          var config = {
+              /*
+               * ...
+               */
+              
+              requireError: function( err ) {
+                  // Error-Handling
+              }
+              
+              /*
+               * ...
+               */
+          };
+  
+    /*
+     * ...
+     */
+  
+  }( this, this.define, this.require ) );
+  ```
 
 ## Events
 

--- a/docs/javascript_en.md
+++ b/docs/javascript_en.md
@@ -429,47 +429,47 @@ Its not necessary to create a module for a collection of functions. For this cas
 
 ## Configuration
 
-It is possible to provide different configurations for different environments. This is archieved using the require.js build. All configuration files are in the `app/config` folder. Here you can provide configs for a specific module or global configs. You can get and set those via the `get` and `set` methods. 
+It is possible to provide different configurations for different environments. This is archieved using the require.js build. All configuration files are in the `app/config` folder. Here you can provide configs for a specific module or global configs. You can get and set those via the `get` and `set` methods.
 
 The configurations are loaded via `config` in the define-block. E.g.:
- 
+
  ```javascript
  define( [ 'config' ], function( config ) {
-   // get configs for module foo
-   var fooConfig = config.get( 'foo' );  
+   // get configs for module example
+   var fooConfig = config.get( 'example' );
  } );
  ```
- 
+
  ### Require.js error handler
- 
+
  There is a function called `requireError` in the global block of the configs. With this function you can implement a special error handling for errors during script loading from require.js. You can use this to track if scripts loaded from a CDN can be loaded. If not you can implement an error handler pushing an event to your analytics or your logging tool. Then you can see the error really early.
- 
+
   ```javascript
   ( function( window, define, require, undefined ) {
       'use strict';
-      
+
       /*
        * ...
        */
-  
+
           var config = {
               /*
                * ...
                */
-              
+
               requireError: function( err ) {
                   // Error-Handling
               }
-              
+
               /*
                * ...
                */
           };
-  
+
     /*
      * ...
      */
-  
+
   }( this, this.define, this.require ) );
   ```
 

--- a/src/components/app/main.js
+++ b/src/components/app/main.js
@@ -67,6 +67,15 @@
             // Extend with global dependencies
         ], function( config ) {
 
+            // custom require.js error handling
+            require.onError = function( err ) {
+                if ( typeof config.requireError === 'function' ) {
+                    config.requireError( err );
+                } else {
+                    throw err;
+                }
+            };
+
             if ( config.dev ) {
 
                 // Allow access to App object via global scope in dev mode


### PR DESCRIPTION
There was mentioned that a graceful error handling for script loading would be good in #15. This adds such a handler to main.js. You can implement your own handler methods in the configuration files.