### PR TITLE
Change clearfix mixin

### DIFF
--- a/src/components/sass/mixins/_clearfix.scss
+++ b/src/components/sass/mixins/_clearfix.scss
@@ -1,5 +1,5 @@
 // Clearfix mixin
-// With clearfix from HTML5 Boilerplate
+// http://cssmojo.com/the-very-latest-clearfix-reloaded/
 
 /*
  * Clearfix: contain floats
@@ -9,18 +9,13 @@
  *    `contenteditable` attribute is included anywhere else in the document.
  *    Otherwise it causes space to appear at the top and bottom of elements
  *    that receive the `clearfix` class.
- * 2. The use of `table` rather than `block` is only necessary if using
- *    `:before` to contain the top-margins of child elements.
  */
 
-@mixin clearfix() {
-    &:before,
-    &:after {
-        content: ' '; /* 1 */
-        display: table; /* 2 */
-    }
 
+@mixin clearfix() {
     &:after {
+        content: " "; /* 1 */
+        display: block;
         clear: both;
     }
 }

--- a/src/components/sass/mixins/_clearfix.scss
+++ b/src/components/sass/mixins/_clearfix.scss
@@ -14,7 +14,7 @@
 
 @mixin clearfix() {
     &:after {
-        content: " "; /* 1 */
+        content: ' '; /* 1 */
         display: block;
         clear: both;
     }


### PR DESCRIPTION
As mentioned here http://cssmojo.com/the-very-latest-clearfix-reloaded/

::before pseudo-element and display table:
- ensure visual consistency with IE 6/7 -> we do not support these browsers
- preventing margin collapsing -> may create more problems than it solves